### PR TITLE
Move `optional=True` representation in toml

### DIFF
--- a/{{cookiecutter.project_name}}/.github/workflows/deploy-docs.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/deploy-docs.yml
@@ -21,7 +21,7 @@ jobs:
 
     - name: Install dependencies.
       run: |
-        poetry install -E docs
+        poetry install --with docs
         
     - name: Build documentation.
       run: |

--- a/{{cookiecutter.project_name}}/.github/workflows/deploy-docs.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/deploy-docs.yml
@@ -31,7 +31,7 @@ jobs:
         cd docs/
         poetry run sphinx-apidoc -o . ../src/{{ cookiecutter.__project_slug}}/ --ext-autodoc -f
         poetry run sphinx-build -b html . _build
-        cp -r _build/html/* ../gh-pages/
+        cp -r _build/* ../gh-pages/
     
     - name: Deploy documentation.
       if: ${{ "{{" }} github.event_name == 'push' {{ "}}" }}

--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -14,6 +14,11 @@ importlib-metadata = "^4.8.0"
 [tool.poetry.group.dev.dependencies]
 pytest = {version = ">=7.1.2"}
 tox = {version = ">=3.25.1"}
+
+[tool.poetry.group.docs]
+optional = true
+
+[tool.poetry.group.docs.dependencies]
 sphinx = {version = ">=6.1.3"}
 sphinx-rtd-theme = {version = ">=1.0.0"}
 sphinx-autodoc-typehints = {version = ">=1.2.0"}
@@ -22,16 +27,6 @@ myst-parser = {version = ">=0.18.1"}
 
 [tool.poetry.scripts]
 {{cookiecutter.project_name}} = "{{cookiecutter.__project_slug}}.cli:main"
-
-[tool.poetry.extras]
-docs = [
-    "sphinx",
-    "sphinx-rtd-theme",
-    "sphinx-autodoc-typehints",
-    "sphinx-click",
-    "myst-parser"
-    ]
-tests = ["pytest", "tox"]
 
 [tool.poetry-dynamic-versioning]
 enable = true

--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -12,13 +12,13 @@ click = "*"
 importlib-metadata = "^4.8.0"
 
 [tool.poetry.group.dev.dependencies]
-pytest = {version = ">=7.1.2", optional = true}
-tox = {version = ">=3.25.1", optional = true}
-sphinx = {version = ">=6.1.3", optional = true}
-sphinx-rtd-theme = {version = ">=1.0.0", optional = true}
-sphinx-autodoc-typehints = {version = ">=1.2.0", optional = true}
-sphinx-click = {version = ">=4.3.0", optional = true}
-myst-parser = {version = ">=0.18.1", optional = true}
+pytest = {version = ">=7.1.2"}
+tox = {version = ">=3.25.1"}
+sphinx = {version = ">=6.1.3"}
+sphinx-rtd-theme = {version = ">=1.0.0"}
+sphinx-autodoc-typehints = {version = ">=1.2.0"}
+sphinx-click = {version = ">=4.3.0"}
+myst-parser = {version = ">=0.18.1"}
 
 [tool.poetry.scripts]
 {{cookiecutter.project_name}} = "{{cookiecutter.__project_slug}}.cli:main"


### PR DESCRIPTION
I am removing the `optional=True` from `tool.poetry.group.dev.dependencies`.

### Reason:

I converted `sssom-py` to be a product of this cookiecutter. When I `poetry install` for the first time, all's well. But when I do it the second time or run any of the following:
- `poetry install --all-extras`
- `poetry install -E docs`
- `poetry install -E tests`

It deletes `virtualenv` and 3 other packages. 
```
  • Removing distlib (0.3.6)
  • Removing filelock (3.12.2)
  • Removing platformdirs (3.6.0)
  • Removing virtualenv (20.23.1)
  • Updating urllib3 (1.26.16 -> 2.0.3)
```
The next time I run any `poetry` command it errors out saying `virtualenv` doesn't exist. 
```
ModuleNotFoundError: No module named 'virtualenv'
```
The only fix is to reinstall poetry and start over again.

### Investigation:

It seemed like in the `poetry.lock` file all the libraries that were uninstalled had `optional=True`. When I took them out from the toml file.


*Using the latest version of poetry v1.5.1*