### PR TITLE
Updated workflows, tox and toml to accomodate for codespell + ruff

### DIFF
--- a/{{cookiecutter.project_name}}/.github/workflows/qc.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/qc.yml
@@ -25,13 +25,12 @@ jobs:
         uses: snok/install-poetry@v1.3.1
       - name: Install dependencies
         run: poetry install --no-interaction
-
+      
+      - name: Check common spelling errors
+        run: poetry run tox -e codespell
+        
       - name: Check code quality with flake8
-        run: poetry run tox -e flake8
-#       - name: Check package metadata with Pyroma
-#         run: poetry run tox -e pyroma
-      - name: Check static typing with MyPy
-        run: poetry run tox -e mypy
+        run: poetry run tox -e lint
 
       - name: Test with pytest and generate coverage file
         run: poetry run tox -e py

--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -37,12 +37,38 @@ style = "pep440"
 line-length = 100
 target-version = ["py38", "py39", "py310"]
 
-[tool.isort]
-profile = "black"
-multi_line_output = 3
-line_length = 100
-include_trailing_comma = true
-reverse_relative = true
+[tool.ruff]
+ extend-exclude = [
+     "tests/output",
+     "tests/**/output"
+ ]
+
+# Allow autofix for all enabled rules (when `--fix`) is provided.
+fixable = ["ALL"]
+
+# Select or ignore from https://beta.ruff.rs/docs/rules/
+ select = [
+    "B",  # bugbear
+    "D",  # pydocstyle
+    "E",  # pycodestyle errors
+    "F",  # Pyflakes
+    "I",  # isort 
+    "S",  # flake8-bandit
+    "W",  # Warning
+ ]
+
+unfixable = []
+target-version = ["py38", "py39", "py310"]
+
+[tool.ruff.mccabe]
+# Unlike Flake8, default to a complexity level of 10.
+max-complexity = 10
+
+[tool.codespell]
+skip = "*.po,*.ts,.git,pyproject.toml"
+count = ""
+quiet-level = 3
+ignore-words-list = ""
 
 [build-system]
 requires = ["poetry-core>=1.0.0", "poetry-dynamic-versioning"]

--- a/{{cookiecutter.project_name}}/tox.ini
+++ b/{{cookiecutter.project_name}}/tox.ini
@@ -12,9 +12,8 @@ skipsdist = True
 envlist =
     # always keep coverage-clean first
     coverage-clean
-    lint
-    flake8
-    mypy
+    lint-fix
+    codespell-write
     docstr-coverage
     py
 
@@ -31,14 +30,26 @@ deps = coverage
 skip_install = true
 commands = coverage erase
 
-[testenv:lint]
+# Tbis is used during development
+[testenv:lint-fix]
 deps =
     black
-    isort
+    ruff
 skip_install = true
 commands =
     black src/ tests/
-    isort src/ tests/
+    ruff --fix src/ tests/
+description = Run linters.
+
+# This is used for QC checks.
+[testenv:lint]
+deps =
+    black
+    ruff
+skip_install = true
+commands =
+    black --check --diff src/ tests/
+    ruff check src/ tests/
 description = Run linters.
 
 [testenv:doclint]
@@ -49,40 +60,21 @@ commands =
     rstfmt docs/source/
 description = Run documentation linters.
 
-[testenv:flake8]
+[testenv:codespell]
+description = Run spell checker.
 skip_install = true
-deps =
-    darglint
-    flake8<5.0.0
-    flake8-black
-    flake8-bandit
-    flake8-bugbear
-    flake8-colors
-    flake8-docstrings
-    flake8-isort
-    flake8-print
-    pydocstyle
-commands =
-    flake8 src/ tests/
-description = Run the flake8 tool with several plugins (bandit, docstrings, import order, pep8 naming).
+deps = 
+    codespell
+    tomli  # required for getting config from pyproject.toml
+commands = codespell src/ tests/
 
-#########################
-# Flake8 Configuration  #
-# (.flake8)             #
-#########################
-[flake8]
-ignore =
-    DAR101 # Missing parameter(s) in Docstring: - with_git_hash
-    DAR201 # Missing "Returns" in Docstring: - return
-    DAR301 # Missing "Yields" in Docstring: - yield
-    E111 # indentation is not a multiple of 4
-    T201 # print found.
-
-[testenv:mypy]
-deps = mypy
+[testenv:codespell-write]
+description = Run spell checker and write corrections.
 skip_install = true
-commands = mypy --install-types --non-interactive --ignore-missing-imports src/
-description = Run the mypy tool to check static typing on the project.
+deps = 
+    codespell
+    tomli
+commands = codespell src/ tests/ --write-changes
 
 [testenv:docstr-coverage]
 skip_install = true


### PR DESCRIPTION
- [x] Add `ruff`
- [ ] Add `codespell`
- [ ] Remove `flake8` [included with `ruff`]
- [ ] Remove `isort`  [included with `ruff`]