### PR TITLE
Add poetry invocation to final test

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,9 +113,11 @@ And as the last line says: `congratulations :)`!! Your project is ready to evolv
 
 On the command line, type the `project_name`. In this example, `ABCD`:
 ```
-ABCD run
+poetry run ABCD run
 ```
 Should return `Hello, **greeting_recipient value chosen during setup**`
+
+To run commands within the poetry environment either preface the command with `poetry run`, i.e. `poetry run /path-to/my-command --options` or open the poetry shell with `poetry shell`.
 
 # Future updates to the project's boilerplate code
 


### PR DESCRIPTION
This is a really minor fix. The original statement doesn't invoke the poetry environment before running the demo script. I also added a quick statement to mention how to invoke the poetry environment.