### PR TITLE
Add docstring to conf.py to prevent linting failure.

### DIFF
--- a/{{cookiecutter.project_name}}/docs/conf.py
+++ b/{{cookiecutter.project_name}}/docs/conf.py
@@ -1,3 +1,4 @@
+"""Configuration file for the Sphinx documentation builder."""
 # Configuration file for the Sphinx documentation builder.
 #
 # For the full list of built-in configuration values, see the documentation:

--- a/{{cookiecutter.project_name}}/docs/conf.py
+++ b/{{cookiecutter.project_name}}/docs/conf.py
@@ -1,6 +1,4 @@
 """Configuration file for the Sphinx documentation builder."""
-# Configuration file for the Sphinx documentation builder.
-#
 # For the full list of built-in configuration values, see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 


### PR DESCRIPTION
Another quick-fix. This time conf.py generates a listing failure due to a missing docstring on the initial commit from a newly made repository. I'm happy to tweak this if you'd like it to have a different docstring, be placed somewhere else, or if you want to change the comment underneath to remove redundancy.